### PR TITLE
Added a TLS alert message 115

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -304,6 +304,7 @@ enum AlertDescription {
     unsupported_extension           = 110, /**< RFC 5246, section 7.2.2 */
     unrecognized_name               = 112, /**< RFC 6066, section 3 */
     bad_certificate_status_response = 113, /**< RFC 6066, section 8 */
+    unknown_psk_identity            = 115, /**< RFC 4279, section 2 */
     no_application_protocol         = 120
 };
 


### PR DESCRIPTION
Added a new TLS alert message unknown_psk_identity (115) from RFC 4279,  section 2.